### PR TITLE
Improve search results for Philadelphia

### DIFF
--- a/explore/static/js/map_creation.js
+++ b/explore/static/js/map_creation.js
@@ -37,7 +37,11 @@ var overlay = document.getElementById('map-overlay');
 
 
 map.on('load', function() {
-  var geocoder = new MapboxGeocoder({accessToken: mapboxgl.accessToken});
+  var geocoder = new MapboxGeocoder({
+    accessToken: mapboxgl.accessToken,
+    country: 'us',
+    bbox: [-75.280296, 39.867004, -74.955833, 40.137959],
+  });
   map.addControl(geocoder);
 
   //load interactive layers into the map


### PR DESCRIPTION
Several users of the map mentioned to me that the geocoder autocomplete result were not relevant. Because this map only contains data for Philadelphia and we expect all of our users to be interested in the Philadelphia area, I used a bounding box parameter to limit all results to Philadelphia and a country parameter to limit all results to the US.

I have found that this drastically improves the autocomplete results.

### Before

![image](https://user-images.githubusercontent.com/1809908/34944532-012d4ae4-f9ce-11e7-9a74-18f2000dd6b2.png)

### After

![image](https://user-images.githubusercontent.com/1809908/34944509-e1b10d0e-f9cd-11e7-9b1a-71985e0cb5d5.png)